### PR TITLE
Retrieve paged requests (#27)

### DIFF
--- a/src/PlexRequests.Core/IRequestService.cs
+++ b/src/PlexRequests.Core/IRequestService.cs
@@ -9,6 +9,9 @@ namespace PlexRequests.Core
     public interface IRequestService
     {
         Task<Request> GetRequestById(Guid id);
+
+        Task<Paged<Request>> GetPaged(string title, PlexMediaTypes? mediaType, bool? isApproved, Guid? userId, int? page,
+            int? pageSize);
         Task<Request> GetExistingMovieRequest(AgentTypes agentType, string agentSourceId);
         Task<List<Request>> GetExistingTvRequests(AgentTypes agentType, string agentSourceId);
         Task Create(Request request);

--- a/src/PlexRequests.Core/RequestService.cs
+++ b/src/PlexRequests.Core/RequestService.cs
@@ -23,6 +23,11 @@ namespace PlexRequests.Core
             return await _requestRepository.GetOne(x => x.Id == id);
         }
 
+        public async Task<Paged<Request>> GetPaged(string title, PlexMediaTypes? mediaType, bool? isApproved, Guid? userId, int? page, int? pageSize)
+        {
+            return await _requestRepository.GetPaged(title, mediaType, isApproved, userId, page, pageSize);
+        }
+
         public async Task<Request> GetExistingMovieRequest(AgentTypes agentType, string agentSourceId)
         {
             return await _requestRepository.GetOne(x =>

--- a/src/PlexRequests.Store/IRequestRepository.cs
+++ b/src/PlexRequests.Store/IRequestRepository.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using PlexRequests.Store.Enums;
 using PlexRequests.Store.Models;
 
 namespace PlexRequests.Store
@@ -10,6 +11,9 @@ namespace PlexRequests.Store
     {
         Task Create(Request request);
         Task<List<Request>> GetMany(Expression<Func<Request, bool>> filter = null);
+
+        Task<Paged<Request>> GetPaged(string title, PlexMediaTypes? mediaType, bool? isApproved, Guid? userId, int? page,
+            int? pageSize);
         Task<Request> GetOne(Expression<Func<Request, bool>> filter = null);
         Task Delete(Guid id);
     }

--- a/src/PlexRequests.Store/Models/Paged.cs
+++ b/src/PlexRequests.Store/Models/Paged.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace PlexRequests.Store.Models
+{
+    public class Paged<T> where T : class
+    {
+        public int TotalPages { get; set; }
+        public int PageSize { get; set; }
+        public int Page { get; set; }
+        public List<T> Items { get; set; }
+    }
+}

--- a/src/PlexRequests.Store/RequestRepository.cs
+++ b/src/PlexRequests.Store/RequestRepository.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+using PlexRequests.Store.Enums;
 using PlexRequests.Store.Models;
 
 namespace PlexRequests.Store
@@ -23,7 +25,62 @@ namespace PlexRequests.Store
             var cursor = await GetRequestsCursor(filter);
             return await cursor.ToListAsync();
         }
-        
+
+        public async Task<Paged<Request>> GetPaged(string title, PlexMediaTypes? mediaType, bool? isApproved, Guid? userId, int? page, int? pageSize)
+        {
+            var query = Collection.AsQueryable();
+
+            if (!string.IsNullOrEmpty(title))
+            {
+                query = query.Where(x => x.Title.ToLower().Contains(title.ToLower()));
+            }
+            
+            if (mediaType != null)
+            {
+                query = query.Where(x => x.MediaType == mediaType);
+            }
+
+            if (isApproved != null)
+            {
+                query = query.Where(x => x.IsApproved == isApproved);
+            }
+
+            if (userId != null)
+            {
+                query = query.Where(x => x.RequestedByUserId == userId);
+            }
+
+            if (page == null)
+            {
+                page = 1;
+            }
+
+            if (pageSize == null)
+            {
+                pageSize = 10;
+            }
+
+            var totalItems = await query.CountAsync();
+
+            var totalPages = (int)Math.Ceiling(totalItems / (double)pageSize);
+
+            page -= 1;
+
+            query = query.OrderByDescending(x => x.Created)
+                 .Skip(pageSize.Value * page.Value)
+                 .Take(pageSize.Value);
+
+            var items = await query.ToListAsync();
+
+            return new Paged<Request>
+            {
+                Page = page.Value + 1,
+                PageSize = pageSize.Value,
+                TotalPages = totalPages,
+                Items = items
+            };
+        }
+
         public async Task<Request> GetOne(Expression<Func<Request, bool>> filter = null)
         {
             var cursor = await GetRequestsCursor(filter);

--- a/src/PlexRequests.TheMovieDb/Models/MovieDetails.cs
+++ b/src/PlexRequests.TheMovieDb/Models/MovieDetails.cs
@@ -22,7 +22,7 @@ namespace PlexRequests.TheMovieDb.Models
         public List<ProductionCountry> Production_Countries { get; set; }
         public string Release_Date { get; set; }
         public int Revenue { get; set; }
-        public int Runtime { get; set; }
+        public int? Runtime { get; set; }
         public List<SpokenLanguage> Spoken_Languages { get; set; }
         public string Status { get; set; }
         public string Tagline { get; set; }

--- a/src/PlexRequests.UnitTests/Models/Requests/CreateMovieRequestCommandHandlerTests.cs
+++ b/src/PlexRequests.UnitTests/Models/Requests/CreateMovieRequestCommandHandlerTests.cs
@@ -195,6 +195,7 @@ namespace PlexRequests.UnitTests.Models.Requests
             _createdRequest.Title.Should().Be(_movieDetails.Title);
             _createdRequest.ImagePath.Should().Be(_movieDetails.Poster_Path);
             _createdRequest.AirDate.Should().Be(DateTime.Parse(_movieDetails.Release_Date));
+            _createdRequest.Created.Should().BeCloseTo(DateTime.UtcNow, 500);
         }
 
         private void WhenCommandActionIsCreated()

--- a/src/PlexRequests.UnitTests/Models/Requests/CreateTvRequestCommandHandlerTests.cs
+++ b/src/PlexRequests.UnitTests/Models/Requests/CreateTvRequestCommandHandlerTests.cs
@@ -347,6 +347,7 @@ namespace PlexRequests.UnitTests.Models.Requests
             _createdRequest.Title.Should().Be(_tvDetails.Name);
             _createdRequest.AirDate.Should().Be(DateTime.Parse(_tvDetails.First_Air_Date));
             _createdRequest.ImagePath.Should().Be(_tvDetails.Poster_Path);
+            _createdRequest.Created.Should().BeCloseTo(DateTime.UtcNow, 500);
 
             for (var i = 0; i < expectedSeasonCount; i++)
             {

--- a/src/PlexRequests.UnitTests/Models/Requests/GetPagedRequestQueryHandlerTests.cs
+++ b/src/PlexRequests.UnitTests/Models/Requests/GetPagedRequestQueryHandlerTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture;
+using AutoMapper;
+using FluentAssertions;
+using NSubstitute;
+using PlexRequests.Core;
+using PlexRequests.Mapping;
+using PlexRequests.Models.Requests;
+using PlexRequests.Store.Enums;
+using PlexRequests.Store.Models;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace PlexRequests.UnitTests.Models.Requests
+{
+    public class GetPagedRequestQueryHandlerTests
+    {
+        private readonly GetPagedRequestQueryHandler _underTest;
+        private readonly IRequestService _requestService;
+        private readonly IClaimsPrincipalAccessor _claimsAccessor;
+
+        private readonly Fixture _fixture;
+
+        private GetPagedRequestQuery _query;
+        private Paged<Request> _pagedRequest;
+        private Func<Task<GetPagedRequestQueryResult>> _queryAction;
+        private Guid _currentUserId;
+
+        public GetPagedRequestQueryHandlerTests()
+        {
+            var mapperConfig = new MapperConfiguration(opts => { opts.AddProfile(new RequestProfile()); });
+            var mapper = mapperConfig.CreateMapper();
+            
+            _requestService = Substitute.For<IRequestService>();
+            _claimsAccessor = Substitute.For<IClaimsPrincipalAccessor>();
+            
+            _underTest = new GetPagedRequestQueryHandler(mapper, _requestService, _claimsAccessor);
+
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        private void Returns_Requests_From_Request_Service()
+        {
+            this.Given(x => x.GivenAQuery())
+                .Given(x => x.GivenManyRequests())
+                .When(x => x.WhenQueryActionIsCreated())
+                .Then(x => x.ThenQueryReturnsCorrectResponse())
+                .BDDfy();
+        }
+        
+        [Fact]
+        private void Gets_Current_Users_UserId_If_Include_Users_Requests()
+        {
+            this.Given(x => x.GivenAQuery())
+                .Given(x => x.GivenCurrentUsersRequestsOnly())
+                .Given(x => x.GivenManyRequests())
+                .Given(x => x.GivenAUsersClaimAccessor())
+                .When(x => x.WhenQueryActionIsCreated())
+                .Then(x => x.ThenQueryReturnsCorrectResponse())
+                .Then(x => x.ThenCurrentUsersUserIdWasUsed())
+                .BDDfy();
+        }
+
+        private void GivenAQuery()
+        {
+            _query = _fixture.Create<GetPagedRequestQuery>();
+        }
+
+        private void GivenCurrentUsersRequestsOnly()
+        {
+            _query.IncludeCurrentUsersOnly = true;
+        }
+
+        private void GivenAUsersClaimAccessor()
+        {
+            _currentUserId = _fixture.Create<Guid>();
+            _claimsAccessor.UserId.Returns(_currentUserId);
+        }
+        
+        private void GivenManyRequests()
+        {
+            _pagedRequest = _fixture.Create<Paged<Request>>();
+            
+            _requestService.GetPaged(Arg.Any<string>(), Arg.Any<PlexMediaTypes?>(), Arg.Any<bool?>(), Arg.Any<Guid?>(),
+                Arg.Any<int?>(), Arg.Any<int?>()).Returns(_pagedRequest);
+        }
+
+        private void WhenQueryActionIsCreated()
+        {
+            _queryAction = async () => await _underTest.Handle(_query, CancellationToken.None);
+        }
+
+        private async Task ThenQueryReturnsCorrectResponse()
+        {
+            var result = await _queryAction();
+
+            result.Should().NotBeNull();
+            result.Items.Count.Should().Be(_pagedRequest.Items.Count);
+            result.Should().BeEquivalentTo(_pagedRequest, options => options.ExcludingMissingMembers());
+        }
+
+        private void ThenCurrentUsersUserIdWasUsed()
+        {
+            _requestService.Received().GetPaged(Arg.Any<string>(), Arg.Any<PlexMediaTypes?>(), Arg.Any<bool?>(), Arg.Is<Guid?>(_currentUserId),
+                Arg.Any<int?>(), Arg.Any<int?>());
+        }
+    }
+}

--- a/src/PlexRequests/Controllers/RequestController.cs
+++ b/src/PlexRequests/Controllers/RequestController.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using PlexRequests.Models.Requests;
+using PlexRequests.Store.Enums;
 
 namespace PlexRequests.Controllers
 {
@@ -44,6 +45,26 @@ namespace PlexRequests.Controllers
             await _mediator.Send(command);
             
             return Ok();
+        }
+
+        [HttpGet("")]
+        public async Task<ActionResult<GetPagedRequestQueryResult>> GetRequests([FromQuery] string title,
+            [FromQuery] PlexMediaTypes? mediaType, [FromQuery] bool? includeCurrentUsersOnly, [FromQuery] bool? isApproved,
+            [FromQuery] int? page, [FromQuery] int? pageSize)
+        {
+            var query = new GetPagedRequestQuery
+            {
+                Title = title,
+                MediaType = mediaType,
+                IncludeCurrentUsersOnly = includeCurrentUsersOnly,
+                IsApproved = isApproved,
+                Page = page,
+                PageSize = pageSize
+            };
+
+            var response = await _mediator.Send(query);
+
+            return Ok(response);
         }
     }
 }

--- a/src/PlexRequests/Mapping/RequestProfile.cs
+++ b/src/PlexRequests/Mapping/RequestProfile.cs
@@ -8,6 +8,7 @@ namespace PlexRequests.Mapping
     {
         public RequestProfile()
         {
+            CreateMap<RequestViewModel, Request>();
             CreateMap<RequestSeasonViewModel, RequestSeason>();
             CreateMap<RequestEpisodeViewModel, RequestEpisode>();
         }

--- a/src/PlexRequests/Models/Requests/CreateMovieRequestCommandHandler.cs
+++ b/src/PlexRequests/Models/Requests/CreateMovieRequestCommandHandler.cs
@@ -61,7 +61,8 @@ namespace PlexRequests.Models.Requests
                 RequestedByUserName = _claimsPrincipalAccessor.Username,
                 Title = movieDetail.Title,
                 AirDate = DateTime.Parse(movieDetail.Release_Date),
-                ImagePath = movieDetail.Poster_Path
+                ImagePath = movieDetail.Poster_Path,
+                Created = DateTime.UtcNow
             };
 
             await _requestService.Create(newRequest);

--- a/src/PlexRequests/Models/Requests/CreateTvRequestCommandHandler.cs
+++ b/src/PlexRequests/Models/Requests/CreateTvRequestCommandHandler.cs
@@ -72,7 +72,8 @@ namespace PlexRequests.Models.Requests
                 RequestedByUserName = _claimsPrincipalAccessor.Username,
                 Title = tvDetails.Name,
                 AirDate = DateTime.Parse(tvDetails.First_Air_Date),
-                ImagePath = tvDetails.Poster_Path
+                ImagePath = tvDetails.Poster_Path,
+                Created = DateTime.UtcNow
             };
 
             await _requestService.Create(tvRequest);

--- a/src/PlexRequests/Models/Requests/GetPagedRequestQuery.cs
+++ b/src/PlexRequests/Models/Requests/GetPagedRequestQuery.cs
@@ -1,0 +1,15 @@
+using MediatR;
+using PlexRequests.Store.Enums;
+
+namespace PlexRequests.Models.Requests
+{
+    public class GetPagedRequestQuery : IRequest<GetPagedRequestQueryResult>
+    {
+        public string Title { get; set; }
+        public PlexMediaTypes? MediaType { get; set; }
+        public bool? IsApproved { get; set; }
+        public bool? IncludeCurrentUsersOnly { get; set; }
+        public int? Page { get; set; }
+        public int? PageSize { get; set; }
+    }
+}

--- a/src/PlexRequests/Models/Requests/GetPagedRequestQueryHandler.cs
+++ b/src/PlexRequests/Models/Requests/GetPagedRequestQueryHandler.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using MediatR;
+using PlexRequests.Core;
+using PlexRequests.Models.ViewModels;
+
+namespace PlexRequests.Models.Requests
+{
+    public class GetPagedRequestQueryHandler : IRequestHandler<GetPagedRequestQuery, GetPagedRequestQueryResult>
+    {
+        private readonly IMapper _mapper;
+        private readonly IRequestService _requestService;
+        private readonly IClaimsPrincipalAccessor _claimsAccessor;
+
+        public GetPagedRequestQueryHandler(IMapper mapper,
+            IRequestService requestService, 
+            IClaimsPrincipalAccessor claimsAccessor)
+        {
+            _mapper = mapper;
+            _requestService = requestService;
+            _claimsAccessor = claimsAccessor;
+        }
+
+        public async Task<GetPagedRequestQueryResult> Handle(GetPagedRequestQuery request, CancellationToken cancellationToken)
+        {
+            Guid? userGuid = null;
+
+            if (request.IncludeCurrentUsersOnly != null && request.IncludeCurrentUsersOnly.Value)
+            {
+                userGuid = _claimsAccessor.UserId;
+            }
+            
+            var pagedResponse = await _requestService.GetPaged(request.Title, request.MediaType, request.IsApproved,
+                userGuid, request.Page, request.PageSize);
+
+            var requestViewModels = _mapper.Map<List<RequestViewModel>>(pagedResponse.Items);
+
+            return new GetPagedRequestQueryResult
+            {
+                Page = pagedResponse.Page,
+                PageSize = pagedResponse.PageSize,
+                TotalPages = pagedResponse.TotalPages,
+                Items = requestViewModels
+            };
+        }
+    }
+}

--- a/src/PlexRequests/Models/Requests/GetPagedRequestQueryResult.cs
+++ b/src/PlexRequests/Models/Requests/GetPagedRequestQueryResult.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using PlexRequests.Models.ViewModels;
+
+namespace PlexRequests.Models.Requests
+{
+    public class GetPagedRequestQueryResult
+    {
+        public int TotalPages { get; set; }
+        public int PageSize { get; set; }
+        public int Page { get; set; }
+        public List<RequestViewModel> Items { get; set; }
+    }
+}

--- a/src/PlexRequests/Models/ViewModels/RequestViewModel.cs
+++ b/src/PlexRequests/Models/ViewModels/RequestViewModel.cs
@@ -1,22 +1,20 @@
 using System;
 using System.Collections.Generic;
-using MongoDB.Bson.Serialization.Attributes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using PlexRequests.Store.Enums;
 
-namespace PlexRequests.Store.Models
+namespace PlexRequests.Models.ViewModels
 {
-    public class Request
+    public class RequestViewModel
     {
-        [BsonId] 
         public Guid Id { get; set; }
         public string Title { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
         public PlexMediaTypes MediaType { get; set; }
-        public AgentTypes AgentType { get; set; }
-        public string AgentSourceId { get; set; }
         public int? PlexRatingKey { get; set; }
-        public Guid RequestedByUserId { get; set; }
         public string RequestedByUserName { get; set; }
-        public List<RequestSeason> Seasons { get; set; }
+        public List<RequestSeasonViewModel> Seasons { get; set; }
         public bool IsApproved { get; set; }
         public string ImagePath { get; set; }
         public DateTime AirDate { get; set; }

--- a/src/PlexRequests/Startup.cs
+++ b/src/PlexRequests/Startup.cs
@@ -68,6 +68,7 @@ namespace PlexRequests
                     {"Bearer", new string[] { }},
                 };
                 options.AddSecurityRequirement(security);
+                options.DescribeAllEnumsAsStrings();
             });
 
             ConfigureLogging();


### PR DESCRIPTION
- Can now retrieve requests in a paginated format
- Added `Created` date to a request
- Swagger set to describe all enums as strings