### PR TITLE
Refresh token

### DIFF
--- a/src/PlexRequests.Core/Services/ITokenService.cs
+++ b/src/PlexRequests.Core/Services/ITokenService.cs
@@ -1,9 +1,12 @@
-﻿using PlexRequests.Repository.Models;
+﻿using System.Security.Claims;
+using PlexRequests.Repository.Models;
 
 namespace PlexRequests.Core.Services
 {
     public interface ITokenService
     {
         string CreateToken(User user);
+        RefreshToken CreateRefreshToken();
+        ClaimsPrincipal GetPrincipalFromAccessToken(string accessToken);
     }
 }

--- a/src/PlexRequests.Core/Services/TokenService.cs
+++ b/src/PlexRequests.Core/Services/TokenService.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using PlexRequests.Core.Settings;
@@ -12,10 +14,17 @@ namespace PlexRequests.Core.Services
 {
     public class TokenService : ITokenService
     {
+        private readonly ILogger<TokenService> _logger;
+        private const int AccessTokenLifespanMinutes = 10;
+        private const int RefreshTokenLifespanDays = 1;
+
         private readonly AuthenticationSettings _authSettings;
 
-        public TokenService(IOptions<AuthenticationSettings> authSettings)
+        public TokenService(
+            IOptions<AuthenticationSettings> authSettings,
+            ILogger<TokenService> logger)
         {
+            _logger = logger;
             _authSettings = authSettings.Value;
         }
 
@@ -35,17 +44,69 @@ namespace PlexRequests.Core.Services
                 claims.Add(new Claim(ClaimTypes.Role, role));
             }
 
+            var expiry = DateTime.UtcNow.AddMinutes(AccessTokenLifespanMinutes);
+            //Remove milliseconds from the time as it gets stripped when the token is serialised
+            expiry = expiry.AddMilliseconds(-expiry.Millisecond);
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(claims),
-                Expires = DateTime.UtcNow.AddDays(7),
+                Expires = expiry,
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(secretKey), SecurityAlgorithms.HmacSha256Signature),
                 Audience = "PlexRequests",
                 Issuer = "PlexRequests"
             };
 
+            user.InvalidateTokensBefore = expiry;
+
             var token = tokenHandler.CreateToken(tokenDescriptor);
             return tokenHandler.WriteToken(token);
+        }
+
+        public RefreshToken CreateRefreshToken()
+        {
+            var randomNumber = new byte[32];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(randomNumber);
+                var refreshToken = Convert.ToBase64String(randomNumber);
+                return new RefreshToken(refreshToken, DateTime.UtcNow.AddDays(RefreshTokenLifespanDays));
+            }
+        }
+
+        public ClaimsPrincipal GetPrincipalFromAccessToken(string accessToken)
+        {
+            var tokenValidationParamers = new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(_authSettings.SecretKey)),
+                RequireExpirationTime = true,
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidIssuer = "PlexRequests",
+                ValidAudience = "PlexRequests",
+                ValidateLifetime = false,
+                ClockSkew = TimeSpan.Zero
+            };
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            SecurityToken securityToken;
+            ClaimsPrincipal principal;
+            try
+            {
+                principal = tokenHandler.ValidateToken(accessToken, tokenValidationParamers, out securityToken);
+            }
+            catch (SecurityTokenException securityTokenException)
+            {
+                _logger.LogDebug(securityTokenException.ToString());
+                return null;
+            }
+
+            if (!(securityToken is JwtSecurityToken jwtSecurityToken) || !jwtSecurityToken.Header.Alg.Equals(SecurityAlgorithms.HmacSha256, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return null;
+            }
+
+            return principal;
         }
     }
 }

--- a/src/PlexRequests.Repository/Models/RefreshToken.cs
+++ b/src/PlexRequests.Repository/Models/RefreshToken.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace PlexRequests.Repository.Models
+{
+    public class RefreshToken
+    {
+        public string Token { get; set; }
+        public DateTime Expires { get; set; }
+
+        public RefreshToken()
+        {
+        }
+
+        public RefreshToken(string token, DateTime expires)
+        {
+            Token = token;
+            Expires = expires;
+        }
+    }
+}

--- a/src/PlexRequests.Repository/Models/User.cs
+++ b/src/PlexRequests.Repository/Models/User.cs
@@ -15,5 +15,7 @@ namespace PlexRequests.Repository.Models
         public bool IsDisabled { get; set; }
         public DateTime LastLogin { get; set; }
         public List<string> Roles { get; set; }
+        public RefreshToken RefreshToken { get; set; }
+        public DateTime InvalidateTokensBefore { get; set; }
     }
 }

--- a/src/PlexRequests.UnitTests/Models/Auth/AddAdminCommandHandlerTests.cs
+++ b/src/PlexRequests.UnitTests/Models/Auth/AddAdminCommandHandlerTests.cs
@@ -93,6 +93,7 @@ namespace PlexRequests.UnitTests.Models.Auth
                 .Given(x => x.GivenAnAdminAccount(false))
                 .Given(x => x.GivenValidPlexCredentials())
                 .Given(x => x.GivenAnAdminIsCreated())
+                .Given(x => x.GivenARefreshTokenIsReturned())
                 .When(x => x.WhenACommandActionIsCreated())
                 .Then(x => x.ThenAnAdminUserWasCreated())
                 .BDDfy();
@@ -106,6 +107,7 @@ namespace PlexRequests.UnitTests.Models.Auth
                 .Given(x => x.GivenValidPlexCredentials())
                 .Given(x => x.GivenAPlexServerWasFound())
                 .Given(x => x.GivenAServerIsCreated())
+                .Given(x => x.GivenARefreshTokenIsReturned())
                 .When(x => x.WhenACommandActionIsCreated())
                 .Then(x => x.ThenAServerWasCreated(false))
                 .BDDfy();
@@ -120,6 +122,7 @@ namespace PlexRequests.UnitTests.Models.Auth
                 .Given(x => x.GivenAPlexServerWasFound())
                 .Given(x => x.GivenAServerIsCreated())
                 .Given(x => x.GivenServerLibraries())
+                .Given(x => x.GivenARefreshTokenIsReturned())
                 .When(x => x.WhenACommandActionIsCreated())
                 .Then(x => x.ThenAServerWasCreated(true))
                 .BDDfy();
@@ -133,6 +136,7 @@ namespace PlexRequests.UnitTests.Models.Auth
                 .Given(x => x.GivenValidPlexCredentials())
                 .Given(x => x.GivenAPlexServerWasFound())
                 .Given(x => x.GivenATokenIsReturned())
+                .Given(x => x.GivenARefreshTokenIsReturned())
                 .When(x => x.WhenACommandActionIsCreated())
                 .Then(x => x.ThenCommandReturnsAccessToken())
                 .BDDfy();

--- a/src/PlexRequests.UnitTests/Models/Auth/AddAdminCommandHandlerTests.cs
+++ b/src/PlexRequests.UnitTests/Models/Auth/AddAdminCommandHandlerTests.cs
@@ -45,6 +45,7 @@ namespace PlexRequests.UnitTests.Models.Auth
         private PlexServer _createdServer;
         private PlexMediaContainer _plexLibraryContainer;
         private string _createdToken;
+        private RefreshToken _createdRefreshToken;
 
         public AddAdminCommandHandlerTests()
         {
@@ -137,6 +138,19 @@ namespace PlexRequests.UnitTests.Models.Auth
                 .BDDfy();
         }
 
+        [Fact]
+        private void Refresh_Token_Is_Returned_Successfully()
+        {
+            this.Given(x => x.GivenACommand())
+                .Given(x => x.GivenAnAdminAccount(false))
+                .Given(x => x.GivenValidPlexCredentials())
+                .Given(x => x.GivenAPlexServerWasFound())
+                .Given(x => x.GivenARefreshTokenIsReturned())
+                .When(x => x.WhenACommandActionIsCreated())
+                .Then(x => x.ThenCommandReturnsRefreshToken())
+                .BDDfy();
+        }
+
         private void GivenACommand()
         {
             _command = _fixture.Create<AddAdminCommand>();
@@ -199,6 +213,13 @@ namespace PlexRequests.UnitTests.Models.Auth
             _tokenService.CreateToken(Arg.Any<Repository.Models.User>()).Returns(_createdToken);
         }
 
+        private void GivenARefreshTokenIsReturned()
+        {
+            _createdRefreshToken = _fixture.Create<RefreshToken>();
+
+            _tokenService.CreateRefreshToken().Returns(_createdRefreshToken);
+        }
+
         private void ThenAnErrorIsThrown(string message, string description, HttpStatusCode httpStatusCode)
         {
             _commandAction.Should().Throw<PlexRequestException>()
@@ -258,6 +279,14 @@ namespace PlexRequests.UnitTests.Models.Auth
 
             response.Should().NotBeNull();
             response.AccessToken.Should().Be(_createdToken);
+        }
+
+        private async Task ThenCommandReturnsRefreshToken()
+        {
+            var response = await _commandAction();
+
+            response.Should().NotBeNull();
+            response.RefreshToken.Should().Be(_createdRefreshToken.Token);
         }
     }
 }

--- a/src/PlexRequests.UnitTests/Models/Auth/UserLoginCommandHandlerTests.cs
+++ b/src/PlexRequests.UnitTests/Models/Auth/UserLoginCommandHandlerTests.cs
@@ -84,6 +84,7 @@ namespace PlexRequests.UnitTests.Models.Auth
                 .Given(x => x.GivenValidPlexCredentials())
                 .Given(x => x.GivenAMatchingUser(false))
                 .Given(x => x.GivenAUserIsUpdated())
+                .Given(x => x.GivenARefreshTokenIsCreated())
                 .When(x => x.WhenACommandActionIsCreated())
                 .Then(x => x.ThenUserIsUpdatedCorrectly())
                 .BDDfy();
@@ -96,6 +97,7 @@ namespace PlexRequests.UnitTests.Models.Auth
                 .Given(x => x.GivenValidPlexCredentials())
                 .Given(x => x.GivenAMatchingUser(false))
                 .Given(x => x.GivenATokenIsCreated())
+                .Given(x => x.GivenARefreshTokenIsCreated())
                 .When(x => x.WhenACommandActionIsCreated())
                 .Then(x => x.ThenATokenIsReturnedCorrectly())
                 .BDDfy();

--- a/src/PlexRequests/ApiRequests/Auth/Commands/AddAdminCommandHandler.cs
+++ b/src/PlexRequests/ApiRequests/Auth/Commands/AddAdminCommandHandler.cs
@@ -61,13 +61,16 @@ namespace PlexRequests.ApiRequests.Auth.Commands
 
             _logger.LogDebug("Plex SignIn Successful");
 
-            var adminUser = await CreateAdminUser(plexUser);
+            var refreshToken = _tokenService.CreateRefreshToken();
+            
+            var adminUser = await CreateAdminUser(plexUser, refreshToken);
 
             await CreateAdminServer(plexUser);
 
             var result = new UserLoginCommandResult
             {
-                AccessToken = _tokenService.CreateToken(adminUser)
+                AccessToken = _tokenService.CreateToken(adminUser),
+                RefreshToken = refreshToken.Token
             };
 
             return result;
@@ -90,7 +93,7 @@ namespace PlexRequests.ApiRequests.Auth.Commands
             }
         }
 
-        private async Task<User> CreateAdminUser(PlexRequests.Plex.Models.User plexUser)
+        private async Task<User> CreateAdminUser(PlexRequests.Plex.Models.User plexUser, RefreshToken refreshToken)
         {
             var adminUser = new User
             {
@@ -98,7 +101,8 @@ namespace PlexRequests.ApiRequests.Auth.Commands
                 Email = plexUser.Email,
                 PlexAccountId = plexUser.Id,
                 IsAdmin = true,
-                Roles = new List<string> { PlexRequestRoles.Admin, PlexRequestRoles.User, PlexRequestRoles.Commenter }
+                Roles = new List<string> { PlexRequestRoles.Admin, PlexRequestRoles.User, PlexRequestRoles.Commenter },
+                RefreshToken = refreshToken
             };
 
             _logger.LogInformation("Creating Admin account");

--- a/src/PlexRequests/ApiRequests/Auth/Commands/RefreshTokenCommand.cs
+++ b/src/PlexRequests/ApiRequests/Auth/Commands/RefreshTokenCommand.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace PlexRequests.ApiRequests.Auth.Commands
+{
+    public class RefreshTokenCommand : IRequest<UserLoginCommandResult>
+    {
+        public string AccessToken { get; set; }
+        public string RefreshToken { get; set; }
+    }
+}

--- a/src/PlexRequests/ApiRequests/Auth/Commands/RefreshTokenCommandHandler.cs
+++ b/src/PlexRequests/ApiRequests/Auth/Commands/RefreshTokenCommandHandler.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using PlexRequests.Core.Exceptions;
+using PlexRequests.Core.Services;
+using PlexRequests.Repository.Models;
+
+namespace PlexRequests.ApiRequests.Auth.Commands
+{
+    public class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, UserLoginCommandResult>
+    {
+        private readonly ITokenService _tokenService;
+        private readonly IUserService _userService;
+        private readonly ILogger<RefreshTokenCommandHandler> _logger;
+
+        public RefreshTokenCommandHandler(
+            ITokenService tokenService,
+            IUserService userService,
+            ILogger<RefreshTokenCommandHandler> logger
+            )
+        {
+            _tokenService = tokenService;
+            _userService = userService;
+            _logger = logger;
+        }
+
+        public async Task<UserLoginCommandResult> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
+        {
+            _logger.LogDebug("Attempting to refresh users token");
+
+            if (string.IsNullOrWhiteSpace(request.RefreshToken) || string.IsNullOrWhiteSpace(request.AccessToken))
+            {
+                _logger.LogDebug("RefreshToken or AccessToken was not specified when attempting to refresh a token");
+                throw CreateInvalidTokenException();
+            }
+
+            var principal = _tokenService.GetPrincipalFromAccessToken(request.AccessToken);
+            var userIdClaim = principal?.Claims?.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier);
+
+            var user = await ValidateAndReturnUser(userIdClaim);
+
+            if (!IsUserRefreshTokenValid(user.RefreshToken, request.RefreshToken))
+            {
+                _logger.LogDebug("Refresh token has either expired or does not match the users current refresh token");
+                throw CreateInvalidTokenException();
+            }
+            
+            var accessToken = _tokenService.CreateToken(user);
+            var refreshToken = _tokenService.CreateRefreshToken();
+            user.RefreshToken = refreshToken;
+            
+            await _userService.UpdateUser(user);
+
+            return new UserLoginCommandResult
+            {
+                AccessToken = accessToken,
+                RefreshToken = refreshToken.Token
+            };
+        }
+
+        private async Task<User> ValidateAndReturnUser(Claim userIdClaim)
+        {
+            if (userIdClaim?.Value == null)
+            {
+                _logger.LogDebug("UserId could not be extracted from the claim");
+                throw CreateInvalidTokenException();
+            }
+
+            var user = await _userService.GetUser(Guid.Parse(userIdClaim.Value));
+
+            if (user == null || user.IsDisabled)
+            {
+                _logger.LogDebug($"User either no longer exists or has been disabled");
+                throw CreateInvalidTokenException();
+            }
+
+            return user;
+        }
+
+        private static bool IsUserRefreshTokenValid(RefreshToken userRefreshToken, string refreshTokenToValidate)
+        {
+            if (string.IsNullOrWhiteSpace(userRefreshToken?.Token))
+            {
+                return false;
+            }
+
+            return DateTime.UtcNow <= userRefreshToken.Expires && userRefreshToken.Token.Equals(refreshTokenToValidate, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private static PlexRequestException CreateInvalidTokenException()
+        {
+            return new PlexRequestException("Invalid Token");
+        }
+    }
+}

--- a/src/PlexRequests/ApiRequests/Auth/Commands/UserLoginCommandHandler.cs
+++ b/src/PlexRequests/ApiRequests/Auth/Commands/UserLoginCommandHandler.cs
@@ -53,13 +53,18 @@ namespace PlexRequests.ApiRequests.Auth.Commands
 
             _logger.LogDebug("Found matching PlexRequests User");
 
+            var refreshToken = _tokenService.CreateRefreshToken();
+            var accessToken = _tokenService.CreateToken(plexRequestsUser);
+
             plexRequestsUser.LastLogin = DateTime.UtcNow;
+            plexRequestsUser.RefreshToken = refreshToken;
 
             await _userService.UpdateUser(plexRequestsUser);
 
             var result = new UserLoginCommandResult
             {
-                AccessToken = _tokenService.CreateToken(plexRequestsUser)
+                AccessToken = accessToken,
+                RefreshToken = refreshToken.Token
             };
 
             return result;

--- a/src/PlexRequests/ApiRequests/Auth/Commands/UserLoginCommandResult.cs
+++ b/src/PlexRequests/ApiRequests/Auth/Commands/UserLoginCommandResult.cs
@@ -3,5 +3,6 @@
     public class UserLoginCommandResult
     {
         public string AccessToken { get; set; }
+        public string RefreshToken { get; set; }
     }
 }

--- a/src/PlexRequests/Controllers/AuthController.cs
+++ b/src/PlexRequests/Controllers/AuthController.cs
@@ -35,6 +35,17 @@ namespace PlexRequests.Controllers
             return Ok(result);
         }
 
+        [HttpPost("Refresh")]
+        [AllowAnonymous]
+        [SwaggerResponse(200, "Refresh was successful")]
+        [SwaggerResponse(400, "Refresh unsuccessful due to invalid credentials or bad refresh token", typeof(ApiErrorResponse))]
+        public async Task<ActionResult<UserLoginCommandResult>> Refresh([FromBody] RefreshTokenCommand command)
+        {
+            var result = await _mediator.Send(command);
+
+            return Ok(result);
+        }
+
         [HttpPost("CreateAdmin")]
         [AllowAnonymous]
         [SwaggerOperation(


### PR DESCRIPTION
Added in a basic refresh token implementation for now:

- Only a single log in per user
- New login will revoke access via all previous tokens
- Creating a refresh token will invalidate any others for the user
- AccessToken lifespan is now 10 minutes
- RefreshToken lifespan is now 1 day
