### PR TITLE
Make LastLogin nullable on Users model

### DIFF
--- a/src/PlexRequests.Functions/Features/Users/Models/Detail/UserDetailModel.cs
+++ b/src/PlexRequests.Functions/Features/Users/Models/Detail/UserDetailModel.cs
@@ -8,7 +8,7 @@ namespace PlexRequests.Functions.Features.Users.Models.Detail
         public int Id { get; set; }
         public string Username { get; set; }
         public bool IsDisabled { get; set; }
-        public DateTime LastLogin { get; set; }
+        public DateTime? LastLogin { get; set; }
         public List<string> Roles { get; set; }
     }
 }


### PR DESCRIPTION
LastLogin is now nullable on UserDetailModel returned from GET users function.

Currently any null LastLogin dates from the database were coming back as DateTime.MinValue.